### PR TITLE
Add experimental manjaro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ Builds Vircadia (formerly known as "Project Athena"), an Open Source fork of the
 * Ubuntu 18.04
 * Ubuntu 19.10 (experimental)
 * Ubuntu 20.04 (experimental)
-* Linux Mint 19.3 (experimental)
+* Linux Mint 19.3
+* Debian 10
 * Fedora 31 (experimental, needs to build Qt)
-* Debian 10 (experimental)
 * Amazon Linux 2 (experimental, needs newer cmake)
+* Manjaro (experimental)
 * (more coming soon)
 
 ## Instructions:

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1470,7 +1470,7 @@ my $mem_per_core_qt     = 1.2 * 1024 * 1024;
 
 my $repo         = "https://github.com/kasenvr/project-athena";
 my $qt_repo      = "git://code.qt.io/qt/qt5.git";
-my $repo_tag     = "kasen/core";
+my $repo_tag     = "v0.86.0-k2.1";
 my $repo_tag_path = "";
 
 my $root_dir     = "$ENV{HOME}/Vircadia";

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1244,11 +1244,10 @@ my $data = {
 			'MAKE' => 'make'
 		}
 	},
-	'Manjaro' => {
+	'manjaro' => {
 		has_binary_qt_package => 0,
 		package_manager => 'pacman',
 		source_dependencies => [
-		#'libterm-readline-gnu-perl', no idea what this is
 			'gcc',
 			'git',
 			'make',
@@ -1286,11 +1285,7 @@ my $data = {
 			'autoconf',
 			'automake',
 			'gettext',
-		#'autotools-dev', no idea
-		#'debhelper',
 			'mariadb-libs',
-		#'dh-autoreconf',
-		#'dh-exec',
 			'strip-nondeterminism',
 			'libfbclient',
 			'freetds',
@@ -1303,7 +1298,7 @@ my $data = {
 			'freetds',
 			'libcups',
 			'cups',
-			'dbus-x11',
+			#'dbus-x11', 'dbus', there is two libdbus packages which are in conflict with each other and both used on different flavours
 			'mesa',
 			'libepoxy',
 			'libevdev',
@@ -1321,7 +1316,7 @@ my $data = {
 			'jbigkit',
 			'libjpeg-turbo',
 			'libjpeg6-turbo',
-			'lib32-libltdl', # no non-lib32 available
+			'lib32-libltdl',
 			'xz',
 			'mtdev',
 			'mariadb',
@@ -1351,13 +1346,7 @@ my $data = {
 			'libxkbcommon',
 			'libxkbcommon-x11',
 			'libxtst',
-		#'mysql-common', ??
 			'unixodbc',
-		#'pkg-kde-tools', ??
-		#'po-debconf', ??
-		#'qt5-assistant', ??
-		#'qtchooser', ??
-		#'qttools5-dev-tools', ??
 			'wayland-protocols',
 			'xorgproto',
 			'libx11',

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1243,6 +1243,138 @@ my $data = {
 			# fails to find that make is installed otherwise.
 			'MAKE' => 'make'
 		}
+	},
+	'Manjaro' => {
+		has_binary_qt_package => 0,
+		package_manager => 'pacman',
+		source_dependencies => [
+		#'libterm-readline-gnu-perl', no idea what this is
+			'gcc',
+			'git',
+			'make',
+			'cmake',
+			'curl',
+			'patchelf',
+			'python',
+			'python2',
+			'libdrm',
+			'mesa',
+			'mesa-demos',
+			'libglvnd',
+			'xdg-user-dirs',
+			'python-distro',
+			'harfbuzz',
+			# Qt
+			'double-conversion', 'libxcb', 'pcre2',
+			# Interface
+			'libpulse', 'nss', 'nspr', 'fontconfig', 'libxcursor', 'libxcomposite', 'libxtst', 'libxslt', 'sdl2',
+			# Misc
+			'alsa-lib', 'libxmu', 'libxi', 'freeglut', 'jack', 'libxrandr', 'systemd-libs', 'openssl', 'zlib',
+			# Server
+			'libpulse', 'nss', 'nspr', 'fontconfig', 'libxcursor', 'libxcomposite', 'libxtst', 'libxslt',
+			# Docs
+			'nodejs'
+		],
+		qt_version => '5.12.6',
+		qt_patches => [
+			'aec.patch',
+			'mac-web-video.patch',
+#			'qfloat16.patch',  # Doesn't apply against 5.12.6
+			'qtscript-crash-fix.patch'
+		],
+		qt_source_dependencies => [
+			'autoconf',
+			'automake',
+			'gettext',
+		#'autotools-dev', no idea
+		#'debhelper',
+			'mariadb-libs',
+		#'dh-autoreconf',
+		#'dh-exec',
+			'strip-nondeterminism',
+			'libfbclient',
+			'freetds',
+			'harfbuzz',
+			'icu',
+			'at-spi2-atk',
+			'atk',
+			'at-spi2-core',
+			'cairo',
+			'freetds',
+			'libcups',
+			'cups',
+			'dbus-x11',
+			'mesa',
+			'libepoxy',
+			'libevdev',
+			'expat',
+			'libfbclient',
+			'strip-nondeterminism',
+			'fontconfig',
+			'freetype2',
+			'gdk-pixbuf2',
+			'glib2',
+			'graphite',
+			'gtk3',
+			'icu',
+			'libinput',
+			'jbigkit',
+			'libjpeg-turbo',
+			'libjpeg6-turbo',
+			'lib32-libltdl', # no non-lib32 available
+			'xz',
+			'mtdev',
+			'mariadb',
+			'unixodbc',
+			'pango',
+			'pcre',
+			'pixman',
+			'libpng',
+			'postgresql',
+			'libproxy',
+			'libpulse',
+			'sqlite',
+			'libtiff',
+			'libtommath',
+			'libtool',
+			'libwacom',
+			'wayland',
+			'xcb-util-wm',
+			'xcb-util-image',
+			'xcb-util-keysyms',
+			'xcb-util-renderutil',
+			'libxcb',
+			'libxcomposite',
+			'libxcursor',
+			'libxft',
+			'libxinerama',
+			'libxkbcommon',
+			'libxkbcommon-x11',
+			'libxtst',
+		#'mysql-common', ??
+			'unixodbc',
+		#'pkg-kde-tools', ??
+		#'po-debconf', ??
+		#'qt5-assistant', ??
+		#'qtchooser', ??
+		#'qttools5-dev-tools', ??
+			'wayland-protocols',
+			'xorgproto',
+			'libx11',
+			# Also required
+			'gperf',
+			'bison',
+			'flex',
+			# Extra
+			'jsoncpp',
+			'nss',
+			'libvpx',
+			'opus'
+			],
+		appimage_dependencies => [
+			'imagemagick',
+			'curl'
+		]
 	}
 };
 
@@ -1493,6 +1625,8 @@ sub get_package_list {
 		@packages = read_from_cmd("rpm", "-qa", "--qf", "%{NAME}\\n");
 	} elsif ( $DD->{package_manager} eq "apt" ) {
 		@packages = read_from_cmd("dpkg-query", "--show", "-f", "\${Package}\n");
+	} elsif ( $DD->{package_manager} eq "pacman" ) {
+		@packages = read_from_cmd("pacman", "-Qq");
 	} elsif ( $DD->{package_manager} eq "none" ) {
 		# Nothing
 	} else {
@@ -1568,6 +1702,8 @@ sub install_missing_packages {
 			$ENV{DEBIAN_FRONTEND} = 'noninteractive';
 			sudo_run("apt-get", "update");
 			sudo_run("--preserve-env=DEBIAN_FRONTEND", "apt-get", "install", "-y", @missing);
+		} elsif ( $DD->{package_manager} eq "pacman" ) {
+			sudo_run("pacman", "-S", "--noconfirm", @missing);
 		} elsif ( $DD->{package_manager} eq "none" ) {
 			# Nothing
 		} else {

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1282,6 +1282,7 @@ my $data = {
 			'qtscript-crash-fix.patch'
 		],
 		qt_source_dependencies => [
+			'patch',
 			'autoconf',
 			'automake',
 			'gettext',

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1257,7 +1257,7 @@ my $data = {
 			'python',
 			'python2',
 			'libdrm',
-			'mesa',
+			#'mesa', conflicts with mesa-git and mesa-aco-git
 			'mesa-demos',
 			'libglvnd',
 			'xdg-user-dirs',
@@ -1300,7 +1300,7 @@ my $data = {
 			'libcups',
 			'cups',
 			#'dbus-x11', 'dbus', there is two libdbus packages which are in conflict with each other and both used on different flavours
-			'mesa',
+			#'mesa', conflicts with mesa-git and mesa-aco-git from the AUR
 			'libepoxy',
 			'libevdev',
 			'expat',

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1248,6 +1248,7 @@ my $data = {
 		has_binary_qt_package => 0,
 		package_manager => 'pacman',
 		source_dependencies => [
+			'perl-term-readline-gnu',
 			'gcc',
 			'git',
 			'make',


### PR DESCRIPTION
This adds support for manjaro building. Since manjaro is a rolling release distro and none of the devs are using it, this will probably always be experimental.

Currently I only just completed my initial test and more testing is needed.
I will open this once I am finished with testing some more.

Current issues:
- [ ] manjaro does not get automatically detected because `VERSION_ID` is not available in `/etc/os-release` (manually suppling with `--distro manjaro` works)
- [ ] there is some weird erros about dependencies not being installed which are installed on manjaro-kde (looking into that)
- [ ] there is two packages supplying libdbus which are in conflict with each other. (`dbus` and `dbus-x11`) Both are used by different manjaro flavours.
-> at-spi2-core, which is in `qt_source_dependencies`, requires libdbus, so this could be ignored
- [ ] `mesa` conflicts with packages `mesa-git` and `mesa-aco-git` from the AUR
-> gtk3, which is in `qt_source_dependencies`, requires mesa, so this could be ignored

