### PR TITLE
centos-8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,24 @@ Builds Vircadia (formerly known as "Project Athena"), an Open Source fork of the
 * Linux Mint Debian Edition 4
 * Fedora 31 (needs to build Qt)
 * Amazon Linux 2
+* CentOS 8.2 (see notes below)
 * (more coming soon)
+
+## Notes on CentOS / RHEL 8.x build
+
+Before starting the build:
+
+- Enable PowerTools and EPEL repos
+  dnf install epel-release
+  dnf config-manager --set-enabled PowerTools
+
+- Make sure the basic dev tools are installed
+  dnf groupinstall "Development Tools" "RPM Development Tools"
+
+- CentOS/RHEL has two Python versions, make sure Python 2 is default
+  dnf install python2 python36
+  alternatives --set python /usr/bin/python2
+
 
 ## Unsupported platforms
 

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1540,7 +1540,111 @@ my $data = {
 			'imagemagick',
 			'curl'
 		]
-	}
+	},
+	'centos-8' => {
+		## Should be 100% compatible with RHEL 8 as well.
+		## This assumes basic dev tools are already install using:
+		## dnf groupinstall "Development Tools" "RPM Development Tools"
+		has_binary_qt_package => 0,
+		qt_version => '5.12.6',
+		qt_patches => [
+			'aec.patch',
+			'mac-web-video.patch',
+#			'qfloat16.patch',  # Doesn't apply against 5.12.6
+			'qtscript-crash-fix.patch'
+		],
+		package_manager => 'dnf',
+		source_dependencies => [
+			'git',
+			'perl-Term-ReadLine-Gnu',
+			'cmake',
+			'make',
+			'patchelf',
+			'gcc-c++',
+			'libatomic',
+			'xdg-user-dirs',
+			'tar',
+			'python36',
+			'SDL2-devel',
+			'curl',
+			'unzip'
+		],
+		qt_binary_dependencies => [
+			'qt5-devel',
+			'qt5-qtbase-devel',
+			'qt5-qtmultimedia-devel',
+			'qt5-qtscript-devel',
+			'qt5-qtwebkit-devel',
+			'qt5-qtwebengine-devel',
+			'qt5-qtbase-private-devel'
+		],
+		qt_source_dependencies => [
+			'alsa-lib-devel',
+			'at-spi2-core-devel',
+			'bison',
+			'clang',
+			'clang-devel',
+			'cups-devel',
+			'dbus-devel',
+			'flex',
+			'fontconfig-devel',
+			'glib2-devel',
+			'gperf',
+			'gtk3-devel',
+			'harfbuzz-devel',
+			'jasper-devel',
+			'libdrm-devel',
+			'libICE-devel',
+			'libicu-devel',
+			'libinput-devel',
+			'libjpeg-turbo-devel',
+			'libmng-devel',
+			'libpng-devel',
+			'libproxy-devel',
+			'libSM-devel',
+			'libstdc++-static',
+			'libtiff-devel',
+			'libxkbcommon-devel',
+			'libxkbcommon-x11-devel',
+			'libxcb-devel',
+			'llvm',
+			'llvm-devel',
+			'mesa-libEGL-devel',
+			'mesa-libGL-devel',
+			'mesa-libgbm-devel',
+			'nss-devel',
+			'openssl-devel',
+			'openjpeg2-devel',
+			'patch',
+			'pcre-devel',
+			'pcre2-devel',
+			'pulseaudio-libs-devel',
+			'python2',
+			'qt5-rpm-macros',
+			'sqlite-devel',
+			'systemd-devel',
+			'tar',
+			'unixODBC-devel',
+			'xcb-util-image-devel',
+			'xcb-util-keysyms-devel',
+			'xcb-util-renderutil-devel',
+			'xcb-util-wm-devel',
+			'xkeyboard-config-devel',
+			'zlib-devel',
+			# Possibly unnecessary, optional dependencies of
+			# WebEngine. Should check what's useful and what not.
+			'jsoncpp-devel',
+			'libxslt-devel',
+			'libvpx-devel',
+			'libicu-devel',
+			'libxml2-devel',
+			'opus-devel',
+			'libicu-devel',
+			'libwebp-devel',
+			'libXtst-devel',
+		],
+	},
+
 };
 
 # Valid build targets for the makefile

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1568,6 +1568,7 @@ my $data = {
 			'SDL2-devel',
 			'curl',
 			'unzip'
+			'npm'
 		],
 		qt_binary_dependencies => [
 			'qt5-devel',


### PR DESCRIPTION
This uses elements from the existing fedora and amzn-2 builds along with a few other changes. Tested on CentOS 8.2. Was able to run pkg-scripts to build an RPM and then install the RPM to get a working server. (the RPM needs some dependency tweaks for CentOS and I'll look at that later if I get time). Should be 100% compatible with RHEL 8.2 as well and I suspect will work on CentOS/RHEL 8.0/8.1 as well but haven't tested those.