### PR TITLE
Linux Mint 19.3 work around package conflict

### DIFF
--- a/distros/linuxmint-19.3.cfg
+++ b/distros/linuxmint-19.3.cfg
@@ -148,7 +148,7 @@
                              'libpulse0',
                              'libpulse0',
                              'libsdl2-dev',
-                             'libssl-dev',
+                             'libssl1.0-dev',
                              'libterm-readline-gnu-perl',
                              'libudev-dev',
                              'libxcb-xinerama0-dev',


### PR DESCRIPTION
Only changed Ubuntu 18.04 and forgot Linux Mint 19.3 in #22 