### PR TITLE
Centos 8 support take two

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,33 @@ Builds Vircadia (formerly known as "Project Athena"), an Open Source fork of the
 
 ## Supported platforms
 
-* Ubuntu 18.04
+* Amazon Linux 2
+* CentOS 8.x (see notes below)
+* Debian 10
+* Fedora 31 (needs to build Qt)
+* Fedora 32
+* Linux Mint Debian Edition 4
 * Linux Mint 19.3
+* Ubuntu 18.04
 * Ubuntu 19.10
 * Ubuntu 20.04
-* Debian 10
-* Linux Mint Debian Edition 4
-* Fedora 31 (needs to build Qt)
-* Amazon Linux 2
 * (more coming soon)
+
+## Notes on CentOS / RHEL 8.x builds
+
+Before starting the build
+
+- Enable PowerTools and EPEL repos
+  dnf install epel-release
+  dnf config-manager --set-enabled PowerTools
+
+- Make sure basic dev tools are installed
+  dnf groupinstall "Development Tools" "RPM Development Tools"
+
+- CentOS/RHEL has two Python version, make sure Python 2 is default
+  dnf install python2 python36
+  alternatives --set python /usr/bin/python2
+
 
 ## Unsupported platforms
 

--- a/distros/centos-8.cfg
+++ b/distros/centos-8.cfg
@@ -1,0 +1,111 @@
+#!/usr/bin/perl
+
+## Should be 100% compatible with RHEL 8.x as well.
+## This assumes basic dev tools are already installed using:
+## dnf groupinstall "Development Tools" "RPM Development Tools"
+
+{
+
+    'appimage_dependencies' => [
+                                 'ImageMagick',
+                                 'curl'
+                               ],
+    has_binary_qt_package => 0,
+    package_manager => 'dnf',
+    qt_binary_dependencies => [
+				'qt5-devel',
+				'qt5-qtbase-devel',
+				'qt5-qtmultimedia-devel',
+				'qt5-qtscript-devel',
+				'qt5-qtwebkit-devel',
+				'qt5-qtwebengine-devel',
+				'qt5-qtbase-private-devel'
+			      ],
+    qt_patches => [
+		    'aec.patch',
+		    'mac-web-video.patch',
+		    'qtscript-crash-fix.patch'
+		  ],
+    qt_source_dependencies => [
+				'alsa-lib-devel',
+				'at-spi2-core-devel',
+				'bison',
+				'clang',
+				'clang-devel',
+				'cups-devel',
+				'dbus-devel',
+				'flex',
+				'fontconfig-devel',
+				'glib2-devel',
+				'gperf',
+				'gtk3-devel',
+				'harfbuzz-devel',
+				'jasper-devel',
+				'libdrm-devel',
+				'libICE-devel',
+				'libicu-devel',
+				'libinput-devel',
+				'libjpeg-turbo-devel',
+				'libmng-devel',
+				'libpng-devel',
+				'libproxy-devel',
+				'libSM-devel',
+				'libstdc++-static',
+				'libtiff-devel',
+				'libxkbcommon-devel',
+				'libxkbcommon-x11-devel',
+				'libxcb-devel',
+				'llvm',
+				'llvm-devel',
+				'mesa-libEGL-devel',
+				'mesa-libGL-devel',
+				'mesa-libgbm-devel',
+				'nss-devel',
+				'openssl-devel',
+				'openjpeg2-devel',
+				'patch',
+				'pcre-devel',
+				'pcre2-devel',
+				'pulseaudio-libs-devel',
+				'python2',
+				'qt5-rpm-macros',
+				'sqlite-devel',
+				'systemd-devel',
+				'tar',
+				'unixODBC-devel',
+				'xcb-util-image-devel',
+				'xcb-util-keysyms-devel',
+				'xcb-util-renderutil-devel',
+				'xcb-util-wm-devel',
+				'xkeyboard-config-devel',
+				'zlib-devel',
+				# Possibly unnecessary, optional dependencies of
+				# WebEngine. Should check what's useful and what not.
+				'jsoncpp-devel',
+				'libxslt-devel',
+				'libvpx-devel',
+				'libicu-devel',
+				'libxml2-devel',
+				'opus-devel',
+				'libicu-devel',
+				'libwebp-devel',
+				'libXtst-devel',
+			      ],
+    qt_version => '5.12.6',
+    source_dependencies => [
+			    'git',
+			    'perl-Term-ReadLine-Gnu',
+			    'cmake',
+			    'make',
+			    'patchelf',
+			    'gcc-c++',
+			    'libatomic',
+			    'xdg-user-dirs',
+			    'tar',
+			    'python36',
+			    'SDL2-devel',
+			    'curl',
+			    'unzip'
+			   ],
+
+}


### PR DESCRIPTION
More or less the same code as my previous pull request but reformatted to work with the new version of vircadia-builder. As before, it successfully builds both server and viewer on CentOS 8.2 for me. Server runs with no problems. I can't fully test viewer due to this being a headless server with no graphics card but I can at least load the viewer and see the main window/menu via X over ssh.