### PR TITLE
Add experimental OpenVR support

### DIFF
--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1594,16 +1594,20 @@ sub install_into_appimage {
 	# Clear line
 	info( "\r" . (" " x $prev_len) . "\r");
 
+        # I have got no idea what I am doing, I just want to get libopenvr_api.so in the AppImage
+        my $appimage_libopenvr_apidir = "$appimage_base/vcpkg/bd824a32/installed/x64-linux/lib";
+	info("Copying libopenvr_api.so to $appimage_libopenvr_apidir\n");
+        run("mkdir", "-p", "$appimage_libopenvr_apidir");
+	run("cp", "-dp", "$root_dir/vcpkg/bd824a32/installed/x64-linux/lib/libopenvr_api.so", "$appimage_libopenvr_apidir/libopenvr_api.so");
+        info("\n");
+
+	# Clear line
+	info( "\r" . (" " x $prev_len) . "\r");
+
 	info("Copied : "); info_ok("$inst_copied\n");
 	info("Skipped: "); info_ok("$inst_skipped\n");
 	info("Deleted: "); info_ok("$inst_deleted\n");
 	info("\n");
-
-        # I have got no idea what I am doing, I just want to get libopenvr_api.so in the AppImage
-        my $appimage_libopenvr_apidir = "$appimage_base/vcpkg/bd824a32/installed/x64-linux/lib";
-	info("Copying libopenvr_api.so to $appimage_libopenvr_apidir\n");
-	run("cp", "-dp", "$root_dir/vcpkg/bd824a32/installed/x64-linux/lib/libopenvr_api.so", $appimage_libopenvr_apidir);
-        info("\n");
 
 	info("Creating icons... ");
 	run("convert", "$root_dir/source/interface/icon/interface.ico", "$appimage_base/interface.png");

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1595,10 +1595,9 @@ sub install_into_appimage {
 	info( "\r" . (" " x $prev_len) . "\r");
 
         # I have got no idea what I am doing, I just want to get libopenvr_api.so in the AppImage
-        my $appimage_libopenvr_apidir = "$appimage_base/vcpkg/bd824a32/installed/x64-linux/lib";
-	info("Copying libopenvr_api.so to $appimage_libopenvr_apidir\n");
-        run("mkdir", "-p", "$appimage_libopenvr_apidir");
-	run("cp", "-dp", "$root_dir/vcpkg/bd824a32/installed/x64-linux/lib/libopenvr_api.so", "$appimage_libopenvr_apidir/libopenvr_api.so");
+	info("Copying libopenvr_api.so to $appimage_base/usr/lib64/\n");
+        run("mkdir", "-p", "$appimage_base/usr/lib64/");
+	run("cp", "-dp", "$root_dir/vcpkg/bd824a32/installed/x64-linux/lib/libopenvr_api.so", "$appimage_base/usr/lib64/libopenvr_api.so");
         info("\n");
 
 	# Clear line

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1600,7 +1600,7 @@ sub install_into_appimage {
 	info("\n");
 
         # I have got no idea what I am doing, I just want to get libopenvr_api.so in the AppImage
-        my $appimage_libopenvr_apidir = = "$appimage_base/vcpkg/bd824a32/installed/x64-linux/lib";
+        my $appimage_libopenvr_apidir = "$appimage_base/vcpkg/bd824a32/installed/x64-linux/lib";
 	info("Copying libopenvr_api.so to $appimage_libopenvr_apidir\n");
 	run("cp", "-dp", "$root_dir/vcpkg/bd824a32/installed/x64-linux/lib/libopenvr_api.so", $appimage_libopenvr_apidir);
         info("\n");

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1599,6 +1599,12 @@ sub install_into_appimage {
 	info("Deleted: "); info_ok("$inst_deleted\n");
 	info("\n");
 
+        # I have got no idea what I am doing, I just want to get libopenvr_api.so in the AppImage
+        my $appimage_libopenvr_apidir = = "$appimage_base/vcpkg/bd824a32/installed/x64-linux/lib";
+	info("Copying libopenvr_api.so to $appimage_libopenvr_apidir\n");
+	run("cp", "-dp", "$root_dir/vcpkg/bd824a32/installed/x64-linux/lib/libopenvr_api.so", $appimage_libopenvr_apidir);
+        info("\n");
+
 	info("Creating icons... ");
 	run("convert", "$root_dir/source/interface/icon/interface.ico", "$appimage_base/interface.png");
 	my $max_size = 0;

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1594,7 +1594,8 @@ sub install_into_appimage {
 	# Clear line
 	info( "\r" . (" " x $prev_len) . "\r");
 
-        # I have got no idea what I am doing, I just want to get libopenvr_api.so in the AppImage
+        # Copy libopenvr_api.so from vcpkg into the AppImage
+        # FIXME: Find out how to get the `bd824a32` part of the path and make it change accordingly.
 	info("Copying libopenvr_api.so to $appimage_base/usr/lib64/\n");
         run("mkdir", "-p", "$appimage_base/usr/lib64/");
 	run("cp", "-dp", "$root_dir/vcpkg/bd824a32/installed/x64-linux/lib/libopenvr_api.so", "$appimage_base/usr/lib64/libopenvr_api.so");


### PR DESCRIPTION
This PR makes vircadia-builder copy the missing libopenvr_api.so from the vcpkg folder into the AppImage.
While not being well tested, it does work on my system.
An AppImage build by this is available here: https://appimage.moto9000.moe/experimental/Vircadia-x86_64_v2020.2.5_openvr_experimental.AppImage
Fixes #20 