### PR TITLE
Fix wrong package on Debian 10

### DIFF
--- a/distros/debian-10.cfg
+++ b/distros/debian-10.cfg
@@ -188,7 +188,7 @@
                              'libpulse0',
                              'libpulse0',
                              'libsdl2-dev',
-                             'libssl1.0-dev',
+                             'libssl-dev',
                              'libterm-readline-gnu-perl',
                              'libudev-dev',
                              'libxcb-xinerama0-dev',


### PR DESCRIPTION
This changes ``libssl1.0-dev`` which does not exist on Debian to ``libssl-dev``. Not sure where this came from as an old version of vircadia-builder I had was using ``libssl-dev`` like it should.
Maybe libssl1.0-dev was a thing on older versions of Debian 10, but I assume I just had it changed for my build and forgot to create a PR to fix it.