### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Builds Vircadia (formerly known as "Project Athena"), an Open Source fork of the
 * Amazon Linux 2
 * CentOS 8.x (see notes below)
 * Debian 10
-* Fedora 31 (needs to build Qt)
+* Fedora 31
 * Fedora 32
 * Fedora 33
 * Linux Mint Debian Edition 4
 * Linux Mint 19.3
 * Linux Mint 20.0
-* Ubuntu 18.04
-* Ubuntu 19.10
+* Ubuntu 18.04 (has pre-built Qt)
+* Ubuntu 19.10 (has pre-built Qt)
 * Ubuntu 20.04
 * (more coming soon)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Builds Vircadia (formerly known as "Project Athena"), an Open Source fork of the
 * Debian 10
 * Fedora 31 (needs to build Qt)
 * Fedora 32
-* Fedora 33 (needs PR kasenvr/project-athena#863 )
+* Fedora 33
 * Linux Mint Debian Edition 4
 * Linux Mint 19.3
 * Linux Mint 20.0


### PR DESCRIPTION
This updates the readme to remove mention of PR kasenvr/project-athena#863.
It also removes the info that Qt needs to be build for and replaces it with notes that Ubuntu 18.04 and 19.10 have pre-built Qt available, as all distributions other than those two (and Ubuntu 16.04) will need to build Qt.