### PR TITLE
Fix building on Amazon Linux 2

### DIFF
--- a/distros/amzn-2.cfg
+++ b/distros/amzn-2.cfg
@@ -79,13 +79,16 @@
   'qt_version' => '5.12.6',
   'source_dependencies' => [
                              'SDL2-devel',
-                             'cmake',
+                             'cmake3',
                              'curl',
                              'gcc-c++',
                              'git',
                              'libatomic',
                              'make',
-                             'patchelf',
+                             # patchelf is missing from the repositories. It is not necessarily needed but should be readded if it ever makes it into the repositories.                             
+                             #'patchelf',
+                             # perl-Term-ReadLine-Gnu is needed to prefill standard values. It is not available in the repositories.
+                             #'perl-Term-ReadLine-Gnu',
                              'python3',
                              'tar',
                              'unzip',

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -511,7 +511,13 @@ sub build {
 	mkdir("$root_dir/build");
 	chdir("$root_dir/build");
 
-	run("cmake", "../source");
+    # Use cmake3 on Amazon Linux 2 as cmake always links to cmake version 2
+    if ( $distro eq "amzn-2" ) {
+    	run("cmake3", "../source");
+    } else {
+        run("cmake", "../source");
+    }
+
 	foreach my $target (@build_list) {
 		important("Building target $target\n");
 		run("make", $target, "-j${build_cores}");
@@ -685,7 +691,8 @@ sub adjust_libs_search_func {
 	# Don't touch cmake things
 	return if ( $relpath =~ /CMakeFiles/ );
 
-	if ( -f $abspath && -x $abspath && is_elf($abspath) )  {
+    # Do not run on Amazon Linux 2 as it does not have patchelf
+	if ( -f $abspath && -x $abspath && is_elf($abspath) && $distro ne "amzn-2" )  {
 		patch_rpath($abspath, $File::Find::dir);
 	}
 }
@@ -897,7 +904,11 @@ sub setup_services {
 	unless($opt_skip_systemd_restart) {
 		if ( $services_created ) {
 			info("Reloading systemd config... ");
-			run("systemctl", "--user", "daemon-reload");
+            if ( $distro eq "amzn-2" ) {
+                info("\nAmazon Linux 2 does not support user services. Skipping daemon reload.\n");
+			} else {
+                run("systemctl", "--user", "daemon-reload");
+            }
 			info_ok("done.\n");
 		}
 	}


### PR DESCRIPTION
This PR allows using vircadia-builder to build on Amazon Linux 2 (again?).

- Use "cmake3" on Amazon Linux 2 as "cmake" still only provides version 2.
- Remove patchelf as dependency as there is no matching package in the Amazon Linux 2 repositories.
- Do not patch paths with patchelf on Amazon Linux 2 as it is not available.
- Add info about perl-Term-ReadLine-Gnu as there is no matching package in the Amazon Linux 2 repositores.
- Skip user daemon reload as Amazon Linux 2 does not support user services.