### PR TITLE
Initial aarch64 support

### DIFF
--- a/distros/manjaro.cfg
+++ b/distros/manjaro.cfg
@@ -50,9 +50,6 @@
                                 '-no-icu'
                               ],
   'qt_patches' => [
-                    'aec.patch',
-                    'mac-web-video.patch',
-                    'qtscript-crash-fix.patch'
                   ],
   'qt_source_dependencies' => [
                                 'at-spi2-atk',
@@ -80,7 +77,6 @@
                                 'icu',
                                 'jbigkit',
                                 'jsoncpp',
-                                'lib32-libltdl',
                                 'libcups',
                                 'libepoxy',
                                 'libevdev',
@@ -115,6 +111,7 @@
                                 'patch',
                                 'pcre',
                                 'pixman',
+                                'pkgconf',
                                 'postgresql',
                                 'sqlite',
                                 'strip-nondeterminism',
@@ -130,7 +127,7 @@
                                 'xorgproto',
                                 'xz'
                               ],
-  'qt_version' => '5.12.6',
+  'qt_version' => '5.15.2',
   'source_dependencies' => [
                              'alsa-lib',
                              'cmake',
@@ -166,7 +163,6 @@
                              'nspr',
                              'nspr',
                              'nss',
-                             'nss',
                              'openssl',
                              'patchelf',
                              'pcre2',
@@ -177,6 +173,7 @@
                              'sdl2',
                              'systemd-libs',
                              'xdg-user-dirs',
+                             'zip',
                              'zlib'
                            ]
 }

--- a/distros/ubuntu-18.04.cfg
+++ b/distros/ubuntu-18.04.cfg
@@ -213,6 +213,7 @@
                              'python3-distro',
                              'unzip',
                              'xdg-user-dirs',
+                             'zip',
                              'zlib1g-dev'
                            ]
 }

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -868,7 +868,7 @@ sub install_qt {
 	push @extra_qt_arguments, "-debug"            if ( $opt_qt_debug );
 	push @extra_qt_arguments, "-force-debug-info" if ( $opt_qt_debug_info );
 
-    if ( x86_64 eq (POSIX::uname)[4] ) {
+    if ( "x86_64" eq (POSIX::uname)[4] ) {
 	    run("../qt5/configure", "-opensource", "-confirm-license",
 	    	"-platform", "linux-g++-64",
 		    @{ $DD->{qt_configure_arguments} },
@@ -876,7 +876,7 @@ sub install_qt {
 		    "-prefix", "../qt5-install");
         return;
     }
-    elsif ( aarch64 eq (POSIX::uname)[4] ) {
+    elsif ( "aarch64" eq (POSIX::uname)[4] ) {
 	    run("../qt5/configure", "-opensource", "-confirm-license",
 	    	"-platform", "linux-g++",
 		    @{ $DD->{qt_configure_arguments} },
@@ -884,7 +884,7 @@ sub install_qt {
 		    "-prefix", "../qt5-install");
         return;
     }
-    else
+    else {
         fatal("Unknown machine architecture!\n")
     }
 

--- a/vircadia-builder
+++ b/vircadia-builder
@@ -13,6 +13,7 @@ use File::Copy qw(cp);
 use File::Basename;
 use Cwd qw(abs_path);
 use VircadiaBuilder::Common;
+use POSIX ();
 
 
 $| = 1;
@@ -867,11 +868,26 @@ sub install_qt {
 	push @extra_qt_arguments, "-debug"            if ( $opt_qt_debug );
 	push @extra_qt_arguments, "-force-debug-info" if ( $opt_qt_debug_info );
 
-	run("../qt5/configure", "-opensource", "-confirm-license",
-		"-platform", "linux-g++-64",
-		@{ $DD->{qt_configure_arguments} },
-	        @extra_qt_arguments,
-		"-prefix", "../qt5-install");
+    if ( x86_64 eq (POSIX::uname)[4] ) {
+	    run("../qt5/configure", "-opensource", "-confirm-license",
+	    	"-platform", "linux-g++-64",
+		    @{ $DD->{qt_configure_arguments} },
+	         @extra_qt_arguments,
+		    "-prefix", "../qt5-install");
+        return;
+    }
+    elsif ( aarch64 eq (POSIX::uname)[4] ) {
+	    run("../qt5/configure", "-opensource", "-confirm-license",
+	    	"-platform", "linux-g++",
+		    @{ $DD->{qt_configure_arguments} },
+	         @extra_qt_arguments,
+		    "-prefix", "../qt5-install");
+        return;
+    }
+    else
+        fatal("Unknown machine architecture!\n")
+    }
+
 
 	check_qt_webengine();
 	run("make", "-j${build_cores_qt}");


### PR DESCRIPTION
This PR adds initial aarch64 support.
It also adds `zip` as a dependency to ubuntu 18.04 and manjaro as it is used by vcpkg to create a cache which can save you many hours on aarch64 systems.
Manjaro actually ships with Qt 5.15.x so the changes to the Qt building don't seem necessary anymore.