### PR TITLE
Disable AppStream metadata creation

### DIFF
--- a/vircadia-builder
+++ b/vircadia-builder
@@ -1790,7 +1790,9 @@ sub install_into_appimage {
 	symlink("vircadia/interface/interface", "$appimage_base/AppRun");
 	info_ok("done.\n");
 
-	create_appimage_metadata("$appimage_base/usr/share/metainfo/Vircadia.appdata.xml");
+    # AppStream metadata is apparently not very easy to support. See https://github.com/AppImage/AppImageKit/issues/603
+    # We should just leave this be until the issue is closed.
+	#create_appimage_metadata("$appimage_base/usr/share/metainfo/Vircadia.appdata.xml");
 
 	info("Creating AppImage...");
 	chdir($root_dir);


### PR DESCRIPTION
This PR disables AppStream metadata since it breaks AppImage creation.

I guess I must have not tested it properly when I enabled it. Maybe I assumed that a file that passes the verification on it's own wouldn't break AppImage creation.

It also seems like supporting AppStream inside AppImages isn't easily possible: https://github.com/AppImage/AppImageKit/issues/603