### PR TITLE
Bump appimagetool version to 13

### DIFF
--- a/vircadia-builder
+++ b/vircadia-builder
@@ -116,7 +116,7 @@ my @excluded_system_libs = (
 #	qr/^libz\.so\.1/
 );
 
-my $appimagetool_release = 12;
+my $appimagetool_release = 13;
 my $appimagetool_url = "https://github.com/AppImage/AppImageKit/releases/download/${appimagetool_release}/appimagetool-x86_64.AppImage";
 
 


### PR DESCRIPTION
AppImageKit 13 was released today to fix issue https://github.com/AppImage/AppImageKit/issues/1032
This issue was "preventing" us from getting into their AppImageHub since it broke their automatic testing system.

I didn't specifically test it yet.